### PR TITLE
fix deprecation

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/structs/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.package_name}}/structs/base.py
@@ -5,7 +5,8 @@ __all__ = ["ProtoConvertable"]
 
 
 class ProtoConvertable:
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def from_proto(cls, message: t.Any) -> "ProtoConvertable":
         pass
 


### PR DESCRIPTION
abc.abstractclassmethod is deprecated since python 3.3